### PR TITLE
価格の重複がないようにデータを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -9,7 +9,7 @@ DRINKS = [
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '460' },
+  { name: 'チーズケーキ', price: '470' },
   { name: 'アップルパイ', price: '520' },
   { name: 'ホットサンド', price: '410' }
 ].freeze


### PR DESCRIPTION
条件「特定の条件で、お会計額が想定の金額と異なる。」の "特定の条件" の要因となっていた値を改善。
チーズケーキ と チャイ が同額だったため、これを選ぶとバグに気づかないケースがあった。