### PR TITLE
Rubocopはプラクティスの要件ではないため設定ファイル不要

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,0 @@
-inherit_gem:
-  rubocop-fjord:
-    - "config/rubocop.yml"


### PR DESCRIPTION
Rubocop実施不要ですが、`.rubocop.yml` があることによって受講生に誤解を与える可能性があるため、 削除したいです。
FBC側のプラクティスの説明にはRubocopに関する言及は無いため、編集予定はありません。