### PR TITLE
fix :  注文番号のインデックスズレと合計金額の文字列連結バグを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -29,5 +29,5 @@ order1 = take_order(DRINKS)
 puts "フードメニューはいかがですか?"
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price].to_i + DRINKS[order2][:price].to_i
+total = DRINKS[order1][:price].to_i + FOODS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,34 +1,33 @@
 # frozen_string_literal: true
-
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: "コーヒー", price: "300" },
+  { name: "カフェラテ", price: "400" },
+  { name: "チャイ", price: "460" },
+  { name: "エスプレッソ", price: "340" },
+  { name: "緑茶", price: "450" },
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: "チーズケーキ", price: "470" },
+  { name: "アップルパイ", price: "520" },
+  { name: "ホットサンド", price: "410" },
 ].freeze
 
 def take_order(menus)
   menus.each.with_index(1) do |menu, i|
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
-  print '>'
-  order_number = gets.to_i
+  print ">"
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
 
-puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
+puts "bugカフェへようこそ！ご注文は？ 番号でどうぞ"
 order1 = take_order(DRINKS)
 
-puts 'フードメニューはいかがですか?'
+puts "フードメニューはいかがですか?"
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = FOODS[order1][:price].to_i + DRINKS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
### 変更内容
- 注文番号のインデックスがずれている問題修正
  - ユーザーは1始まりで番号を入力しますが、配列は0始まりのため、表示される商品名と実際の注文がずれていた
- 合計金額が正しく計算されない
  - 文字列の `price` で計算されていた
  - 合計計算で配列が逆だった（`FOODS[order1]` → `DRINKS[order1]`、`DRINKS[order2] → FOODS[order2]`）

### 実行結果
```
bugカフェへようこそ！ご注文は？ 番号でどうぞ
(1)コーヒー: 300円
(2)カフェラテ: 400円
(3)チャイ: 460円
(4)エスプレッソ: 340円
(5)緑茶: 450円
>2
カフェラテ(400円)ですね。
フードメニューはいかがですか?
(1)チーズケーキ: 470円
(2)アップルパイ: 520円
(3)ホットサンド: 410円
>3
ホットサンド(410円)ですね。
お会計は810円になります。ありがとうございました！
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* **注文処理の改善** - 選択した項目の処理ロジックを修正し、正確な注文処理を実現
* **合計金額計算の修正** - 価格計算アルゴリズムを改善し、正確な合計金額の表示に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->